### PR TITLE
Do not suggest to potentially use builtin echo

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Please run the following commands now to configure the link between Kubernetes and StorageOS(*):
 
 ClusterIP=$(kubectl get svc/{{ .Values.service.name }} --namespace {{ .Values.service.namespace }} -o custom-columns=IP:spec.clusterIP --no-headers=true)
-ApiAddress=$(echo -n "tcp://$ClusterIP:{{ .Values.service.externalPort }}" | base64)
+ApiAddress=$(/bin/echo -n "tcp://$ClusterIP:{{ .Values.service.externalPort }}" | base64)
 kubectl patch secret/{{ .Values.api.secretName }} --namespace {{ .Values.api.secretNamespace }} --patch "{\"data\": {\"apiAddress\": \"$ApiAddress\"}}"
 
 *) Unfortunately this is needed until the Kubernetes apiserver can use kube-dns to resolve service 


### PR DESCRIPTION
From man(1) echo on MacOS:
  Some shells may provide a builtin echo command which is similar or
  identical to this utility.  Most notably, the builtin echo in sh(1) does
  not accept the -n option.

Following the setup instructions of the chart it's quite hard to spot
if builtin echo is used which is why it might be better to use absolute
path.