### PR TITLE
Increase timeouts and require more fails before taking node offline

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -30,13 +30,16 @@ spec:
         - containerPort: {{ .Values.service.internalPort }}
           name: api
         livenessProbe:
-          initialDelaySeconds: 30
-          failureThreshold: 3
+          initialDelaySeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 10
           httpGet:
             path: /v1/health
             port: api
         readinessProbe:
           initialDelaySeconds: 5
+          timeoutSeconds: 10
+          failureThreshold: 10
           httpGet:
             path: /v1/health
             port: api


### PR DESCRIPTION
We saw k8s restarting before the node had initialised - increase the timeout and nuber of fails before restart.