### PR TITLE
Add daemonset selector

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
+  selector:
+    matchLabels:
+      app: {{ template "name" . }}
   template:
     metadata:
       name: {{ template "fullname" . }}


### PR DESCRIPTION
Latest versions of k8s require that any template labels match
with the controller selector. In this case, the daemonset controller
selector need to match the pods label defined in its own template.

This has been solved for CSI daemonset. It is not a priority, but new versions of k8s would not validate the yaml without it. 