### PR TITLE
Add ingress TLS support

### DIFF
--- a/README-CSI.md
+++ b/README-CSI.md
@@ -95,8 +95,7 @@ Parameter | Description | Default
 `initContainer.repository` | StorageOS init container image repository | `storageos/init`
 `initContainer.tag` | StorageOS init container image tag | `0.1`
 `initContainer.pullPolicy` | StorageOS init container image pull policy | `IfNotPresent`
-`csiDriverRegistrar.repository` | CSI Driver Registrar container image repository |
-`quay.io/k8scsi/driver-registrar`
+`csiDriverRegistrar.repository` | CSI Driver Registrar container image repository | `quay.io/k8scsi/driver-registrar`
 `csiDriverRegistrar.tag` | CSI Driver Registrar container image tag | `v0.2.0`
 `csiDriverRegistrar.pullPolicy` | CSI Driver Registrar container image pull policy | `IfNotPresent`
 `csiExternalProvisioner.repository` | CSI External Provisioner container image repository | `quay.io/k8scsi/csi-provisioner`
@@ -122,6 +121,14 @@ Parameter | Description | Default
 `csi.nodePublishCreds.enable` | Enable credentials for CSI node publish volume operations | `false`
 `csi.nodePublishCreds.username` | Username for CSI node publish volume operations |
 `csi.nodePublishCreds.password` | Password for CSI node publish volume operations |
+`ingress.enabled` | Enable ingress controller resource | `false`
+`ingress.hosts[0].name` | Hostname to your StorageOS installation | `storageos.local`
+`ingress.hosts[0].tls` | Utilize TLS backend in ingress | `false`
+`ingress.hosts[0].tlsSecret` | TLS Secret (certificates) | `storageos.local-tls-secret`
+`ingress.hosts[0].annotations` | Annotations for this host's ingress record | `[]`
+`ingress.secrets[0].name` | TLS Secret Name | `nil`
+`ingress.secrets[0].certificate` | TLS Secret Certificate | `nil`
+`ingress.secrets[0].key` | TLS Secret Key | `nil`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Parameter | Description | Default
 `service.externalPort` | External service port | `5705`
 `service.internalPort` | Internal service port | `5705`
 `resources` | Pod resource requests & limits | `{}`
+`ingress.enabled` | Enable ingress controller resource | `false`
+`ingress.hosts[0].name` | Hostname to your StorageOS installation | `storageos.local`
+`ingress.hosts[0].tls` | Utilize TLS backend in ingress | `false`
+`ingress.hosts[0].tlsSecret` | TLS Secret (certificates) | `storageos.local-tls-secret`
+`ingress.hosts[0].annotations` | Annotations for this host's ingress record | `[]`
+`ingress.secrets[0].name` | TLS Secret Name | `nil`
+`ingress.secrets[0].certificate` | TLS Secret Certificate | `nil`
+`ingress.secrets[0].key` | TLS Secret Key | `nil`
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "storageos.fullname" $ }}
+  namespace: {{ $.Values.namespace }}
+  labels:
+    app: {{ template "storageos.name" $ }}
+    chart: {{ template "storageos.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+  annotations:
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .name }}
+  backend:
+    serviceName: {{ $.Values.service.name }}
+    servicePort: 5705
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
   - host: {{ .name }}
   backend:
     serviceName: {{ $.Values.service.name }}
-    servicePort: 5705
+    servicePort: {{ $.Values.service.externalPort }}
 {{- if .tls }}
   tls:
   - hosts:

--- a/templates/svc.yaml
+++ b/templates/svc.yaml
@@ -10,6 +10,12 @@ metadata:
     release: {{ .Release.Name }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.internalPort }}
       targetPort: {{ .Values.service.externalPort }}

--- a/templates/svc.yaml
+++ b/templates/svc.yaml
@@ -13,9 +13,6 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
-  {{- end }}
   ports:
     - port: {{ .Values.service.internalPort }}
       targetPort: {{ .Values.service.externalPort }}

--- a/templates/tls-secrets.yaml
+++ b/templates/tls-secrets.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  labels:
+    app: {{ template "storageos.name" $ }}
+    chart: {{ template "storageos.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,52 @@ service:
   internalPort: 5705
 resources: {}
 
+## Configure the ingress resource that allows you to access the
+## StorageOS API endpoints. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  hosts:
+  - name: storageos.local
+
+    ## Set this to true in order to enable TLS on the ingress record
+    ## A side effect of this will be that the backend joomla service will be connected at port 443
+    tls: false
+
+    ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    tlsSecret: storageos.local-tls
+
+    ## Ingress annotations done as key:value pairs
+    ## If you're using kube-lego, you will want to add:
+    ## kubernetes.io/tls-acme: true
+    ##
+    ## For a full list of possible ingress annotations, please see
+    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/annotations.md
+    ##
+    ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+    annotations:
+    #  kubernetes.io/ingress.class: nginx
+    #  kubernetes.io/tls-acme: true
+
+  secrets:
+  ## If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
+  ## -----BEGIN RSA PRIVATE KEY-----
+  ##
+  ## name should line up with a tlsSecret set further up
+  ## If you're using kube-lego, this is unneeded, as it will create the secret for you if it is not set
+  ##
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  # - name: storageos.local-tls
+  #   key:
+  #   certificate:
+
 csi:
   enable: false
   # provisionCreds are credentials for volume create and delete operations.


### PR DESCRIPTION
- Renames service.yaml to svc.yaml, standard naming in k8s/charts.
- Adds ingress support with TLS. tls-secrets.yaml creates tls secrets.
- Adds support for loadbalancer service type.