### PR TITLE
Pass api creds to daemonset containers

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -74,6 +74,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ADMIN_USERNAME
+          value: {{ .Values.api.username }}
+        - name: ADMIN_PASSWORD
+          value: {{ .Values.api.password }}
         {{- if .Values.cluster.join }}
         - name: JOIN
           value: {{ .Values.cluster.join }}

--- a/templates/daemonset_csi.yaml
+++ b/templates/daemonset_csi.yaml
@@ -92,6 +92,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ADMIN_USERNAME
+          value: {{ .Values.api.username }}
+        - name: ADMIN_PASSWORD
+          value: {{ .Values.api.password }}
         {{- if .Values.cluster.join }}
         - name: JOIN
           value: {{ .Values.cluster.join }}


### PR DESCRIPTION
This is needed to set custom creds for StorageOS.