### PR TITLE
Create init-secrets in storageos NS

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -75,9 +75,15 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: ADMIN_USERNAME
-          value: {{ .Values.api.username }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.adminSecretName }}
+              key: username
         - name: ADMIN_PASSWORD
-          value: {{ .Values.api.password }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.adminSecretName }}
+              key: password
         {{- if .Values.cluster.join }}
         - name: JOIN
           value: {{ .Values.cluster.join }}

--- a/templates/daemonset_csi.yaml
+++ b/templates/daemonset_csi.yaml
@@ -93,9 +93,15 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         - name: ADMIN_USERNAME
-          value: {{ .Values.api.username }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.adminSecretName }}
+              key: username
         - name: ADMIN_PASSWORD
-          value: {{ .Values.api.password }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.adminSecretName }}
+              key: password
         {{- if .Values.cluster.join }}
         - name: JOIN
           value: {{ .Values.cluster.join }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -18,3 +18,21 @@ data:
   apiPassword: {{ default "" .Values.api.password | b64enc | quote }}
 
 {{- end }}
+
+---
+
+# This secret is used to set the initial credentials of the node container.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.adminSecretName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: "kubernetes.io/storageos"
+data:
+  username: {{ default "" .Values.api.username | b64enc | quote }}
+  password: {{ default "" .Values.api.password | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,7 @@ api:
   username: storageos
   password: storageos
 namespace: storageos
+adminSecretName: init-secrets
 service:
   name: storageos
   type: ClusterIP


### PR DESCRIPTION
Createa a separate secret object to store the initial admin credentials.
This secret should be in the same namespace as the node containers to be
referenced by them.