### PR TITLE
Add PodSecurityPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Parameter | Description | Default
 `initContainer.tag` | StorageOS init container image tag | `0.1`
 `initContainer.pullPolicy` | StorageOS init container image pull policy | `IfNotPresent`
 `rbacEnabled` | Use of k8s RBAC features | `true`
+`pspEnabled` | Use of pod security polices | `false`
 `storageclass.name` | StorageOS storage class name | `fast`
 `storageclass.pool` | Default storage pool for storage class | `default`
 `storageclass.fsType` | Default filesystem type for storage class | `ext4`

--- a/templates/podsecuritypolicy.yaml
+++ b/templates/podsecuritypolicy.yaml
@@ -1,0 +1,60 @@
+{{- if not .Values.csi.enable }}
+
+{{- if .Values.pspEnabled -}}
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "storageos.fullname" . }}-psp
+  namespace: {{ .Values.namespace }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - 'SYS_ADMIN'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 5700
+    max: 5800
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "storageos.fullname" . }}-psp-user
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ template "storageos.fullname" . }}-psp
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: {{ template "storageos.fullname" . }}-psp-user
+    namespace: {{ .Values.namespace }}
+roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: Role
+   name: {{ template "storageos.fullname" . }}-psp-user
+subjects:
+- kind: ServiceAccount
+  name: {{ template "storageos.fullname" . }}
+  namespace: {{ .Values.namespace }}
+{{- end -}}
+
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,7 @@ csiExternalAttacher:
   pullPolicy: Always
 
 rbacEnabled: true
+pspEnabled: false
 
 cluster:
   # To generate a join token see:


### PR DESCRIPTION
@darkowlzz  can you tell me wich service account should I be using to integrate with CSI? I use storageos service account for non csi. 

Once a k8s cluster enables the psp admission controller, every single pod must be run with a PSP definition, otherwise it doesn't start. 

I can set a role for storageos-statefulset-sa and storageos-daemonset-sa if you think is appropriate. 