### PR TITLE
service selector for daemonset only

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -22,6 +22,7 @@ spec:
         chart: {{ template "storageos.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        kind: daemonset
     spec:
       hostPID: true
       hostNetwork: true

--- a/templates/daemonset_csi.yaml
+++ b/templates/daemonset_csi.yaml
@@ -21,6 +21,7 @@ spec:
         chart: {{ template "storageos.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        kind: daemonset
     spec:
       serviceAccount: {{ template "storageos.fullname" . }}-daemonset-sa
       hostPID: true

--- a/templates/statefulset_csi.yaml
+++ b/templates/statefulset_csi.yaml
@@ -23,6 +23,7 @@ spec:
         chart: {{ template "storageos.chart" . }}
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
+        kind: statefulset
     spec:
       serviceAccount: {{ template "storageos.fullname" . }}-statefulset-sa
       containers:

--- a/templates/svc.yaml
+++ b/templates/svc.yaml
@@ -21,3 +21,4 @@ spec:
   selector:
     app: {{ template "storageos.name" . }}
     release: {{ .Release.Name }}
+    kind: daemonset


### PR DESCRIPTION
Since daemonset and statefulset templates have the same labels, the
service selector was selecting the statefulset pods as well. Due to
this, some of the requests were being sent to the statefulset pods,
resulting in `Connection refused`, because those pods don't expose any
port.

This change adds a new label `kind` whose value is the kind of the
resource group and sets service selector to select the daemonset kind.