### PR TITLE
Update CSI helper containers' version

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -18,12 +18,12 @@ csiDriverRegistrar:
 
 csiExternalProvisioner:
   repository: quay.io/k8scsi/csi-provisioner
-  tag: canary
+  tag: v0.3.0
   pullPolicy: Always
 
 csiExternalAttacher:
   repository: quay.io/k8scsi/csi-attacher
-  tag: canary
+  tag: v0.3.0
   pullPolicy: Always
 
 rbacEnabled: true


### PR DESCRIPTION
Canary tags of the helper containers need some new permission. Use
v0.3.0 for now.