### PR TITLE
secretNamespace change

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -36,7 +36,7 @@ cluster:
   # join: node1,node2,node3
   # or
   # join: 10.1.5.07,10.1.5.08,10.1.5.09
-  join: 
+  join:
 
   # sharedDir should be set if running kubelet in a container.  This should
   # be the path shared into to kubelet container, typically:
@@ -49,7 +49,7 @@ storageclass:
   fsType: ext4
 api:
   secretName: storageos-api
-  secretNamespace: default
+  secretNamespace: storageos
   # secrets are namespace specific, create 1+N for every namespace.
   address: storageos:5705
   # address is used to generate the ApiAddress value in the secret. This


### PR DESCRIPTION
Changed secretNamespace value to storageos to reflect that the rest of the helm release runs in the storageos namespace. 